### PR TITLE
Refactor sign-up field selectors and simplify password generation

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,38 @@
+from playwright.async_api import async_playwright
+
+from config import CONFIG
+from Utils.log import log
+
+
+async def fetch_fingerprint():
+    """Retrieve and apply a browser fingerprint."""
+    log("Fetching Fingerprint...", "yellow")
+    # TODO: integrate fingerprint service
+    log("Fingerprint fetched and applied", "green")
+
+
+async def launch_browser():
+    """Launch a Chromium browser with optional proxy settings.
+
+    Returns:
+        tuple: (playwright instance, browser, page)
+    """
+    proxy = None
+    if CONFIG['USE_PROXY']:
+        log("Applying proxy settings...", "green")
+        proxy = {
+            'server': f"{CONFIG['PROXY_USERNAME']}:{CONFIG['PROXY_PASSWORD']}@{CONFIG['PROXY_IP']}:{CONFIG['PROXY_PORT']}"
+        }
+        log("Proxy settings applied", "green")
+
+    log("Launching browser...", "green")
+    playwright = await async_playwright().start()
+    browser = await playwright.chromium.launch(headless=False, proxy=proxy)
+    page = await browser.new_page()
+    page.set_default_timeout(3600000)
+
+    viewport = await page.evaluate(
+        "() => ({width: document.documentElement.clientWidth, height: document.documentElement.clientHeight})"
+    )
+    log(f"Viewport: [Width: {viewport['width']} Height: {viewport['height']}]", "green")
+    return playwright, browser, page

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,5 @@ CONFIG = {
     'PROXY_IP': 'ip',
     'PROXY_PORT': 'port',
     'NAMES_FILE': 'src/Utils/names.txt',
-    'WORDS_FILE': 'src/Utils/words5char.txt',
     'ACCOUNTS_FILE': 'accounts.txt',
 }

--- a/src/index.py
+++ b/src/index.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 from pathlib import Path
 import random
-from playwright.async_api import async_playwright
 
+from auth import fetch_fingerprint, launch_browser
 from config import CONFIG
 from Utils.log import log
 from Utils import recMail
@@ -12,32 +12,14 @@ from Utils import recMail
 async def start():
     os.system('cls' if os.name == 'nt' else 'clear')
     log("Starting...", "green")
+    await fetch_fingerprint()
 
-    log("Fetching Fingerprint...", "yellow")
-    # TODO: integrate fingerprint service
-    log("Fingerprint fetched and applied", "green")
-
-    proxy = None
-    if CONFIG['USE_PROXY']:
-        log("Applying proxy settings...", "green")
-        proxy = {
-            'server': f"{CONFIG['PROXY_USERNAME']}:{CONFIG['PROXY_PASSWORD']}@{CONFIG['PROXY_IP']}:{CONFIG['PROXY_PORT']}"
-        }
-        log("Proxy settings applied", "green")
-
-    log("Launching browser...", "green")
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=False, proxy=proxy)
-        page = await browser.new_page()
-        page.set_default_timeout(3600000)
-
-        viewport = await page.evaluate(
-            "() => ({width: document.documentElement.clientWidth, height: document.documentElement.clientHeight})"
-        )
-        log(f"Viewport: [Width: {viewport['width']} Height: {viewport['height']}]", "green")
-
+    playwright, browser, page = await launch_browser()
+    try:
         await create_account(page)
+    finally:
         await browser.close()
+        await playwright.stop()
 
 
 def delay(time: int):
@@ -46,29 +28,37 @@ def delay(time: int):
 
 async def create_account(page):
     await page.goto("https://outlook.live.com/owa/?nlp=1&signup=1")
-    await page.wait_for_selector(SELECTORS['USERNAME_INPUT'])
+
+    username_input = page.get_by_role("textbox", name="Create a new email address")
+    await username_input.wait_for()
 
     personal_info = await generate_personal_info()
 
-    await page.fill(SELECTORS['USERNAME_INPUT'], personal_info['username'])
-    await page.keyboard.press("Enter")
+    await username_input.fill(personal_info['username'])
+    await username_input.press("Enter")
 
     password = await generate_password()
-    await page.wait_for_selector(SELECTORS['PASSWORD_INPUT'])
-    await page.fill(SELECTORS['PASSWORD_INPUT'], password)
-    await page.keyboard.press("Enter")
+    password_input = page.get_by_role("textbox", name="Create password")
+    await password_input.wait_for()
+    await password_input.fill(password)
+    await password_input.press("Enter")
 
-    await page.wait_for_selector(SELECTORS['FIRST_NAME_INPUT'])
-    await page.fill(SELECTORS['FIRST_NAME_INPUT'], personal_info['randomFirstName'])
-    await page.fill(SELECTORS['LAST_NAME_INPUT'], personal_info['randomLastName'])
-    await page.keyboard.press("Enter")
+    first_name_input = page.get_by_test_id("firstNameInput")
+    last_name_input = page.get_by_test_id("lastNameInput")
+    await first_name_input.wait_for()
+    await first_name_input.fill(personal_info['randomFirstName'])
+    await last_name_input.fill(personal_info['randomLastName'])
+    await last_name_input.press("Enter")
 
-    await page.wait_for_selector(SELECTORS['BIRTH_DAY_INPUT'])
+    birth_day_input = page.get_by_test_id("BirthDay")
+    birth_month_input = page.get_by_test_id("BirthMonth")
+    birth_year_input = page.get_by_test_id("BirthYear")
+    await birth_day_input.wait_for()
     await delay(1000)
-    await page.select_option(SELECTORS['BIRTH_DAY_INPUT'], personal_info['birthDay'])
-    await page.select_option(SELECTORS['BIRTH_MONTH_INPUT'], personal_info['birthMonth'])
-    await page.fill(SELECTORS['BIRTH_YEAR_INPUT'], personal_info['birthYear'])
-    await page.keyboard.press("Enter")
+    await birth_day_input.select_option(personal_info['birthDay'])
+    await birth_month_input.select_option(personal_info['birthMonth'])
+    await birth_year_input.fill(personal_info['birthYear'])
+    await birth_year_input.press("Enter")
 
     email = await page.inner_text(SELECTORS['EMAIL_DISPLAY'])
     await page.wait_for_selector(SELECTORS['FUNCAPTCHA'], timeout=60000)
@@ -170,20 +160,10 @@ async def generate_personal_info():
 
 
 async def generate_password():
-    words = Path(CONFIG['WORDS_FILE']).read_text().splitlines()
-    firstword = random.choice(words).strip()
-    secondword = random.choice(words).strip()
-    return f"{firstword}{secondword}{random.randint(0, 9999)}!"
+    return f"SomawDev{random.randint(1000, 99999)}"
 
 
 SELECTORS = {
-    'USERNAME_INPUT': '#usernameInput',
-    'PASSWORD_INPUT': '#Password',
-    'FIRST_NAME_INPUT': '#firstNameInput',
-    'LAST_NAME_INPUT': '#lastNameInput',
-    'BIRTH_DAY_INPUT': '#BirthDay',
-    'BIRTH_MONTH_INPUT': '#BirthMonth',
-    'BIRTH_YEAR_INPUT': '#BirthYear',
     'EMAIL_DISPLAY': '#userDisplayName',
     'DECLINE_BUTTON': '#declineButton',
     'OUTLOOK_PAGE': '#mainApp',


### PR DESCRIPTION
## Summary
- replace CSS selectors with get_by_role and get_by_test_id for username, password, name, and birthdate fields
- remove obsolete selector entries
- generate password as `SomawDev{4-5 digit number}` and remove unused words file config
- factor out fingerprint retrieval and browser launch into `auth` module

## Testing
- `python -m py_compile src/index.py src/config.py src/auth.py`
- `playwright install-deps` *(incomplete: cancelled after package fetch)*
- `playwright install`
- `python src/index.py` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bd61f32ef88333874fbf191225f284